### PR TITLE
Mark symbols in primary interface as public

### DIFF
--- a/lingua/__init__.py
+++ b/lingua/__init__.py
@@ -413,6 +413,8 @@ LanguageDetectorBuilder.from_iso_codes_639_3(IsoCode639_3.ENG, IsoCode639_3.DEU)
 ```
 """
 
+__all__ = ('LanguageDetectorBuilder', 'LanguageDetector', 'IsoCode639_1', 'IsoCode639_3', 'Language', 'LanguageModelFilesWriter', 'TestDataFilesWriter')
+
 from .builder import LanguageDetectorBuilder
 from .detector import LanguageDetector
 from .isocode import IsoCode639_1, IsoCode639_3


### PR DESCRIPTION
Thanks for making lingua!

Adding an `__all__` variable to control the set of variables exported by lingua. This helps with type checking by Pyright. The alternative would be changing to a form such as: ` from .builder import LanguageDetectorBuilder as LanguageDetectorBuilder `

https://github.com/microsoft/pyright/blob/main/docs/typed-libraries.md#library-interface

> Imported symbols are considered private by default. If they use the “import A as A” (a redundant module alias), “from X import A as A” (a redundant symbol alias), or “from . import A” forms, symbol “A” is not private unless the name begins with an underscore. If a file __init__.py uses the form “from .A import X”, symbol “A” is not private unless the name begins with an underscore (but “X” is still private). If a wildcard import (of the form “from X import *”) is used, all symbols referenced by the wildcard are not private.

I assume this only started happening with releases following: https://github.com/pemistahl/lingua-py/issues/63 

![image](https://user-images.githubusercontent.com/10503608/190263698-b368df39-62cc-4631-8230-3b7436cf4084.png)

