### PR TITLE
Softmax instead min-max normalization

### DIFF
--- a/lingua/__init__.py
+++ b/lingua/__init__.py
@@ -288,7 +288,7 @@ each possible language have to satisfy. It can be stated in the following way:
 >>> from lingua import Language, LanguageDetectorBuilder
 >>> languages = [Language.ENGLISH, Language.FRENCH, Language.GERMAN, Language.SPANISH]
 >>> detector = LanguageDetectorBuilder.from_languages(*languages)\
-.with_minimum_relative_distance(0.7)\
+.with_minimum_relative_distance(0.9)\
 .build()
 >>> print(detector.detect_language_of("languages are awesome"))
 None
@@ -315,9 +315,9 @@ to the most likely one? These questions can be answered as well:
 >>> confidence_values = detector.compute_language_confidence_values("languages are awesome")
 >>> for language, value in confidence_values:
 ...     print(f"{language.name}: {value:.2f}")
-ENGLISH: 0.99
-FRENCH: 0.32
-GERMAN: 0.15
+ENGLISH: 0.93
+FRENCH: 0.04
+GERMAN: 0.02
 SPANISH: 0.01
 
 ```
@@ -345,7 +345,7 @@ language only:
 >>> detector = LanguageDetectorBuilder.from_languages(*languages).build()
 >>> confidence_value = detector.compute_language_confidence("languages are awesome", Language.FRENCH)
 >>> print(f"{confidence_value:.2f}")
-0.32
+0.04
 
 ```
 


### PR DESCRIPTION
What do you think about passing results to [softmax function](https://en.wikipedia.org/wiki/Softmax_function) instead min-max normalization? I think it's more clear way. Because, for example, you can have a threshold to filter-out unidentified languages. 

Is there are some pitfalls that aren't clear for me? I've implemented this by slightly changing your code. I've also rounded results. 

It passed _black_ and _mypy_, but not tests. It's throwing me error like:
`INTERNALERROR> UnicodeEncodeError: 'charmap' codec can't encode characters in position 712-720: character maps to <undefined>`

